### PR TITLE
Terminate

### DIFF
--- a/packages/renderer/src/views/CustomerPanel.vue
+++ b/packages/renderer/src/views/CustomerPanel.vue
@@ -28,7 +28,13 @@ export default class CustomerPanel extends Vue {
 
   get coins(): Coin[] {
     const store = useStore()
-    return store.$state.coins
+    return [...store.$state.coins, {
+      id: -1,
+      name: 'Invalid',
+      value: 999,
+      weight: 999,
+      quantity: 999,
+    }]
   }
 
   get machine(): Machine {

--- a/packages/renderer/src/views/MachineryPanel.vue
+++ b/packages/renderer/src/views/MachineryPanel.vue
@@ -92,7 +92,7 @@ export default class CustomerPanel extends Vue {
                   <h2 class="text-2xl tracking-tighter" v-text="coin.name" />
                 </div>
               </div>
-              <input type="number" min="0" max="40" class="led-small" :value="coin.quantity" @input="(e) => updateCoinQuantity(coin, +e.target.value)">
+              <input type="number" :readonly="machine.doorLocked" min="0" max="40" class="led-small" :value="coin.quantity" @input="(e) => updateCoinQuantity(coin, +e.target.value)">
             </div>
           </div>
         </section>
@@ -114,7 +114,7 @@ export default class CustomerPanel extends Vue {
                   <h2 class="text-xl tracking-tighter" v-text="drink.name" />
                 </div>
               </div>
-              <input type="number" min="0" max="20" class="led-small" :value="drink.quantity" @input="(e) => updateDrinkQuantity(drink, +e.target.value)">
+              <input type="number" min="0" max="20" class="led-small" :readonly="machine.doorLocked" :value="drink.quantity" @input="(e) => updateDrinkQuantity(drink, +e.target.value)">
             </div>
           </div>
         </section>


### PR DESCRIPTION
 1. `CustomerPanel`: added the previously missing option for `Invalid Coin` (constructs a `Coin` object with `id` of `-1` -> calls the `checkCoin` interface -> highlights the `INVALID COIN` tag if the error code is not 200)
 2. `MachineryPanel`: adds the missing rule that does not allow data to be changed when 🚪 is locked (3.1.4(3) - `Note that these values can only be changed when the door state is unlocked. Otherwise the values can only be viewed.`) 3.
 3. implement `Terminate`.
    a. 🚪 Automatically unlocked when `Maintainer` is successfully logged in, and `CustomerPanel` returns the user's coins (equivalent to pressing the `Terminate and Return Cash` button on the screen)
    b. `CustomerPanel` cannot be operated if 🚪 is unlocked
    c. `Maintainer` can be logged out via the `Press Here when Finished` button on the `MaintainerPanel` and
        i. In the case of 🚪 locked: the logout is successful and the password box is cleared (before this the user needs to manually lock 🚪 in the `MachineryPanel` and then perform the logout action, otherwise the process is ii)
        ii. in the case of 🚪 unlocked: this button does nothing

> The user (ie: the maintainer) shall terminate use of the maintenance panel (ie: log-out) by pressing a button with the caption “Press Here when Finished”. If the state of the vending machine door is locked, then the log-out request shall be successful and the maintenance panel shall become inactive (ie: the functions can not be used) except for the “Password” text field. However, if the state of the vending machine door is unlocked, then the log-out request shall be ignored.