### PR TITLE
IPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         ]
     },
     "dependencies": {
-        "electron-store": "^8.0.1",
         "pinia": "^2.0.14",
         "vue-class-component": "^7.2.6",
         "vue-template-compiler": "^2.6.14"
@@ -63,7 +62,9 @@
         "VITE_DEV_SERVER_HOST": "127.0.0.1",
         "VITE_DEV_SERVER_PORT": 3344
     },
-    "eslintIgnore": ["**/openapi/*.ts"],
+    "eslintIgnore": [
+        "**/openapi/*.ts"
+    ],
     "keywords": [
         "electron",
         "rollup",

--- a/packages/main/index.ts
+++ b/packages/main/index.ts
@@ -3,7 +3,6 @@ import { app, BrowserWindow, shell, ipcMain, BrowserWindowConstructorOptions } f
 import { release } from 'os';
 import { join } from 'path';
 import installExtension, { REDUX_DEVTOOLS } from 'electron-devtools-installer';
-import Store from 'electron-store';
 import axios from 'axios';
 import 'v8-compile-cache';
 import { unlinkSync } from 'fs';
@@ -22,15 +21,7 @@ process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
 
 let win: BrowserWindow | null = null;
 
-Store.initRenderer();
-
 async function createWindow(path = '', options?: BrowserWindowConstructorOptions) {
-  // clear storage when creates main window
-  if (!path) {
-    const store = new Store()
-    store.clear()
-  }
-
   win = new BrowserWindow({
     title: 'Star6ucks',
     width: 450,
@@ -153,14 +144,6 @@ app.on('window-all-closed', async () => {
   if (process.platform !== 'darwin') app.quit();
 });
 
-app.on('second-instance', () => {
-  if (win) {
-    // Focus on the main window if the user tried to open another
-    if (win.isMinimized()) win.restore();
-    win.focus();
-  }
-});
-
 app.on('activate', () => {
   const allWindows = BrowserWindow.getAllWindows();
   if (allWindows.length) {
@@ -175,6 +158,36 @@ ipcMain.handle('close-other-wins', () => {
     if (win.id > 1) {
       win.close()
     }
+  })
+})
+
+ipcMain.handle('refresh-all-states', () => {
+  BrowserWindow.getAllWindows().forEach(win => {
+    win.webContents.send('refresh-all-states');
+  })
+})
+
+ipcMain.handle('refresh-user-states', () => {
+  BrowserWindow.getAllWindows().forEach(win => {
+    win.webContents.send('refresh-user-states');
+  })
+})
+
+ipcMain.handle('refresh-coin-states', () => {
+  BrowserWindow.getAllWindows().forEach(win => {
+    win.webContents.send('refresh-coin-states');
+  })
+})
+
+ipcMain.handle('refresh-machine-states', () => {
+  BrowserWindow.getAllWindows().forEach(win => {
+    win.webContents.send('refresh-machine-states');
+  })
+})
+
+ipcMain.handle('refresh-drink-states', () => {
+  BrowserWindow.getAllWindows().forEach(win => {
+    win.webContents.send('refresh-drink-states');
   })
 })
 

--- a/packages/main/vite.config.ts
+++ b/packages/main/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   build: {
     outDir: '../../dist/main',
     emptyOutDir: true,
-    minify: process.env./* from mode option */ NODE_ENV === 'production',
+    minify: process.env.NODE_ENV === 'production',
     sourcemap: true,
     lib: {
       entry: 'index.ts',

--- a/packages/renderer/src/main.ts
+++ b/packages/renderer/src/main.ts
@@ -32,8 +32,3 @@ let healthTimer = setInterval(async () => {
   })
 }, 1000)
 
-if (window.ipcRenderer) {
-  window.ipcRenderer.on('main-process-message', (_event, ...args) => {
-    console.log('[Receive Main-process message]:', ...args)
-  })
-}

--- a/packages/renderer/src/utils.ts
+++ b/packages/renderer/src/utils.ts
@@ -1,4 +1,5 @@
 import { CoinApi, DrinkApi, MachineApi, UserApi } from './openapi'
+import { useStore } from './stores/machine'
 
 const baseUrl = 'http://localhost:8081'
 // const baseUrl = 'https://mock.apifox.cn/m1/1108102-0-default'
@@ -7,3 +8,36 @@ export const coinApi = new CoinApi({}, baseUrl)
 export const machineApi = new MachineApi({}, baseUrl)
 export const drinkApi = new DrinkApi({}, baseUrl)
 export const userApi = new UserApi({}, baseUrl)
+
+export const refreshCoinStates = async () => {
+  const store = useStore()
+  const { data: coins } = await coinApi.coinsGet()
+  store.$patch({
+    coins,
+  })
+}
+
+export const refreshDrinkStates = async () => {
+  const store = useStore()
+  const { data: drinks } = await drinkApi.drinksGet()
+  store.$patch({
+    drinks,
+  })
+}
+
+export const refreshUserStates = async () => {
+  const store = useStore()
+  const { data: users } = await userApi.usersGet()
+  store.$patch({
+    users,
+  })
+}
+
+export const refreshMachineStates = async () => {
+  const store = useStore()
+  const { data: machines } = await machineApi.machinesGet()
+  store.$patch({
+    machines,
+  })
+}
+

--- a/packages/renderer/src/views/CustomerPanel.vue
+++ b/packages/renderer/src/views/CustomerPanel.vue
@@ -3,6 +3,7 @@ import Vue from 'vue'
 import { CoffeeMachine, Cola } from '@icon-park/vue'
 import Component from 'vue-class-component'
 import { MutationType } from 'pinia'
+import { ipcRenderer } from 'electron'
 import type { Coin, Drink, Machine } from '../openapi'
 import { useStore } from '../stores/machine'
 import { coinApi, drinkApi } from '../utils'
@@ -150,6 +151,10 @@ export default class CustomerPanel extends Vue {
     this.noChangeAvailableDisplay = false
     this.selectedDrink = null
   }
+
+  testUpdate() {
+    ipcRenderer.invoke('refresh-all-states')
+  }
 }
 </script>
 
@@ -252,6 +257,9 @@ export default class CustomerPanel extends Vue {
           </div>
         </section>
       </aside>
+      <button @click="testUpdate">
+        you should update urself!
+      </button>
     </section>
   </div>
 </template>

--- a/packages/renderer/src/views/CustomerPanel.vue
+++ b/packages/renderer/src/views/CustomerPanel.vue
@@ -151,10 +151,6 @@ export default class CustomerPanel extends Vue {
     this.noChangeAvailableDisplay = false
     this.selectedDrink = null
   }
-
-  testUpdate() {
-    ipcRenderer.invoke('refresh-all-states')
-  }
 }
 </script>
 
@@ -257,9 +253,6 @@ export default class CustomerPanel extends Vue {
           </div>
         </section>
       </aside>
-      <button @click="testUpdate">
-        you should update urself!
-      </button>
     </section>
   </div>
 </template>

--- a/packages/renderer/src/views/CustomerPanel.vue
+++ b/packages/renderer/src/views/CustomerPanel.vue
@@ -28,7 +28,13 @@ export default class CustomerPanel extends Vue {
 
   get coins(): Coin[] {
     const store = useStore()
-    return store.$state.coins
+    return [...store.$state.coins, {
+      id: -1,
+      name: 'Invalid',
+      value: 999,
+      weight: 999,
+      quantity: 999,
+    }]
   }
 
   get machine(): Machine {

--- a/packages/renderer/src/views/MachineryPanel.vue
+++ b/packages/renderer/src/views/MachineryPanel.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { CheckCorrect, Checkbox, CoffeeMachine, Cola, Finance } from '@icon-park/vue'
+import { ipcRenderer } from 'electron'
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import type { Coin, Drink } from '../openapi'
@@ -32,10 +33,7 @@ export default class CustomerPanel extends Vue {
 
     await machineApi.machinesPut([machine])
 
-    const { data: machines } = await machineApi.machinesGet()
-    store.$patch({
-      machines,
-    })
+    ipcRenderer.invoke('refresh-machine-states')
   }
 
   async updateCoinQuantity(coin: Coin, quantity: number) {
@@ -44,10 +42,7 @@ export default class CustomerPanel extends Vue {
     coin.quantity = quantity
     await coinApi.coinsPut([coin])
 
-    const { data: coins } = await coinApi.coinsGet()
-    store.$patch({
-      coins,
-    })
+    ipcRenderer.invoke('refresh-coin-states')
   }
 
   async updateDrinkQuantity(drink: Drink, quantity: number) {
@@ -56,10 +51,7 @@ export default class CustomerPanel extends Vue {
     drink.quantity = quantity
     await drinkApi.drinksPut([drink])
 
-    const { data: drinks } = await drinkApi.drinksGet()
-    store.$patch({
-      drinks,
-    })
+    ipcRenderer.invoke('refresh-drink-states')
   }
 
   mounted() {

--- a/packages/renderer/src/views/MachineryPanel.vue
+++ b/packages/renderer/src/views/MachineryPanel.vue
@@ -92,7 +92,7 @@ export default class CustomerPanel extends Vue {
                   <h2 class="text-2xl tracking-tighter" v-text="coin.name" />
                 </div>
               </div>
-              <input type="number" min="0" max="40" class="led-small" :value="coin.quantity" @input="(e) => updateCoinQuantity(coin, +e.target.value)">
+              <input type="number" :readonly="machine.doorLocked" min="0" max="40" class="led-small" :value="coin.quantity" @input="(e) => updateCoinQuantity(coin, +e.target.value)">
             </div>
           </div>
         </section>
@@ -114,7 +114,7 @@ export default class CustomerPanel extends Vue {
                   <h2 class="text-xl tracking-tighter" v-text="drink.name" />
                 </div>
               </div>
-              <input type="number" min="0" max="20" class="led-small" :value="drink.quantity" @input="(e) => updateDrinkQuantity(drink, +e.target.value)">
+              <input type="number" min="0" max="20" class="led-small" :readonly="machine.doorLocked" :value="drink.quantity" @input="(e) => updateDrinkQuantity(drink, +e.target.value)">
             </div>
           </div>
         </section>

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -1,9 +1,8 @@
-import { defineConfig } from 'vite';
-import resolve, { lib2esm } from 'vite-plugin-resolve';
-import { createVuePlugin } from 'vite-plugin-vue2';
-import electron from 'vite-plugin-electron/renderer';
-import pkg from '../../package.json';
-import { join } from 'path';
+import { join } from 'path'
+import { defineConfig } from 'vite'
+import { createVuePlugin } from 'vite-plugin-vue2'
+import electron from 'vite-plugin-electron/renderer'
+import pkg from '../../package.json'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -12,37 +11,6 @@ export default defineConfig({
   plugins: [
     createVuePlugin(),
     electron(),
-    resolve(
-      /**
-       * Here you can specify other modules
-       * 🚧 You have to make sure that your module is in `dependencies` and not in the` devDependencies`,
-       *    which will ensure that the electron-builder can package it correctly
-       */
-      {
-        // If you use the following modules, the following configuration will work
-        // What they have in common is that they will return - ESM format code snippets
-
-        // ESM format string
-        'electron-store': 'export default require("electron-store");',
-        // Use lib2esm() to easy to convert ESM
-        // Equivalent to
-        /**
-         * sqlite3: () => `
-         * const _M_ = require('sqlite3');
-         * const _D_ = _M_.default || _M_;
-         * export { _D_ as default }
-         * `
-         */
-        sqlite3: lib2esm('sqlite3', { format: 'cjs' }),
-        serialport: lib2esm(
-          // CJS lib name
-          'serialport',
-          // export memebers
-          ['SerialPort', 'SerialPortMock'],
-          { format: 'cjs' }
-        ),
-      }
-    ),
   ],
   base: './',
   resolve: {
@@ -59,4 +27,4 @@ export default defineConfig({
     host: pkg.env.VITE_DEV_SERVER_HOST,
     port: pkg.env.VITE_DEV_SERVER_PORT,
   },
-});
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,13 +1051,6 @@ agent-base@6:
   dependencies:
     debug "4"
 
-ajv-formats@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmmirror.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
-  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
-  dependencies:
-    ajv "^8.0.0"
-
 ajv-keywords@^3.4.1:
   version "3.5.2"
   resolved "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -1071,16 +1064,6 @@ ajv@^6.10.0, ajv@^6.12.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^8.0.0, ajv@^8.6.3:
-  version "8.11.0"
-  resolved "https://registry.npmmirror.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
@@ -1240,11 +1223,6 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmmirror.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
-atomically@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.npmmirror.com/atomically/-/atomically-1.7.0.tgz#c07a0458432ea6dbc9a3506fffa424b48bccaafe"
-  integrity sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==
 
 autoprefixer@^10.4.7:
   version "10.4.7"
@@ -1651,22 +1629,6 @@ concat-stream@^1.6.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-conf@^10.1.2:
-  version "10.1.2"
-  resolved "https://registry.npmmirror.com/conf/-/conf-10.1.2.tgz#50132158f388756fa9dea3048f6b47935315c14e"
-  integrity sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==
-  dependencies:
-    ajv "^8.6.3"
-    ajv-formats "^2.1.1"
-    atomically "^1.7.0"
-    debounce-fn "^4.0.0"
-    dot-prop "^6.0.1"
-    env-paths "^2.2.1"
-    json-schema-typed "^7.0.3"
-    onetime "^5.1.2"
-    pkg-up "^3.1.0"
-    semver "^7.3.5"
-
 config-chain@^1.1.11:
   version "1.1.13"
   resolved "https://registry.npmmirror.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
@@ -1753,13 +1715,6 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmmirror.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
-
-debounce-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmmirror.com/debounce-fn/-/debounce-fn-4.0.0.tgz#ed76d206d8a50e60de0dd66d494d82835ffe61c7"
-  integrity sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==
-  dependencies:
-    mimic-fn "^3.0.0"
 
 debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -1947,13 +1902,6 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dot-prop@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmmirror.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
-  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
-  dependencies:
-    is-obj "^2.0.0"
-
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmmirror.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
@@ -2029,14 +1977,6 @@ electron-publish@23.0.2:
     lazy-val "^1.0.5"
     mime "^2.5.2"
 
-electron-store@^8.0.1:
-  version "8.0.2"
-  resolved "https://registry.npmmirror.com/electron-store/-/electron-store-8.0.2.tgz#95c8cf81c1e1cf48b24f3ceeea24b921c1ff62d7"
-  integrity sha512-9GwUMv51w8ydbkaG7X0HrPlElXLApg63zYy1/VZ/a08ndl0gfm4iCoD3f0E1JvP3V16a+7KxqriCI0c122stiA==
-  dependencies:
-    conf "^10.1.2"
-    type-fest "^2.12.2"
-
 electron-to-chromium@^1.4.147:
   version "1.4.156"
   resolved "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.4.156.tgz#fc398e1bfbe586135351ebfaf198473a82923af5"
@@ -2078,7 +2018,7 @@ entities@^3.0.1:
   resolved "https://registry.npmmirror.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
-env-paths@^2.2.0, env-paths@^2.2.1:
+env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmmirror.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
@@ -2675,13 +2615,6 @@ find-up@^2.1.0:
   integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmmirror.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
 
 find-up@^4.1.0:
   version "4.1.0"
@@ -3392,16 +3325,6 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-
-json-schema-typed@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.npmmirror.com/json-schema-typed/-/json-schema-typed-7.0.3.tgz#23ff481b8b4eebcd2ca123b4fa0409e66469a2d9"
-  integrity sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -3518,14 +3441,6 @@ locate-path@^2.0.0:
   integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
   dependencies:
     p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmmirror.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 locate-path@^5.0.0:
@@ -3670,16 +3585,6 @@ mime@^2.5.2:
   version "2.6.0"
   resolved "https://registry.npmmirror.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
-
-mimic-fn@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmmirror.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmmirror.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
-  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -3878,13 +3783,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
-  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  dependencies:
-    mimic-fn "^2.1.0"
-
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.npmmirror.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -3909,7 +3807,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmmirror.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -3922,13 +3820,6 @@ p-locate@^2.0.0:
   integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmmirror.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -4058,13 +3949,6 @@ pinia@^2.0.14:
   dependencies:
     "@vue/devtools-api" "^6.1.4"
     vue-demi "*"
-
-pkg-up@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmmirror.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
-  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  dependencies:
-    find-up "^3.0.0"
 
 playwright-core@1.22.2:
   version "1.22.2"
@@ -4340,11 +4224,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -4854,11 +4733,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmmirror.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^2.12.2:
-  version "2.13.1"
-  resolved "https://registry.npmmirror.com/type-fest/-/type-fest-2.13.1.tgz#621c84220df0e01a8469002594fc005714f0cfba"
-  integrity sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
This version removes most of the state management from the front-end (except for the interface which is not yet implemented), and the process is similar to the **publish-subscribe** pattern (not sure if this can be compared to Observer): 1.

1. add several `handlers` of `refresh-*-states` at the initialisation of each window
2. when an operation needs to modify the database (a button is pressed to initiate a PUT / DELETE request), the corresponding `refresh-*-states` handler is called manually (invoke)
3. the `handler` starts notifying all windows to initiate GET requests for the corresponding Entity, updating the windows with the new data

