### PR TITLE
MOD: add tests to CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,3 +23,6 @@ jobs:
       - name: Execute Gradle build
         working-directory: ./api
         run: ./gradlew build
+      - name: Run Tests
+        working-directory: ./api
+        run: ./gradlew test


### PR DESCRIPTION
看老师的意思好像是要我们把测试加到 CI 流程里面：

> Dear Yu, 
Ideally, the CI environment should be up after your team established the first code baseline in your project repository. If it is inconvenient to do that, we can still accept it as long as you can demonstrate during presentation your **CI setup with triggers from project repository and automated testing**. Hope this clarifies. 
Cheers,
Boon Kui
