### PR TITLE
refactor(project): Remove some unnecessary code and reformat code

### DIFF
--- a/api/src/main/java/com/mtech/vmcs/controller/DrinkController.java
+++ b/api/src/main/java/com/mtech/vmcs/controller/DrinkController.java
@@ -21,11 +21,6 @@ public class DrinkController {
     return new ResponseEntity<>(drinkService.getAllDrinks(), HttpStatus.OK);
   }
 
-  @GetMapping("/{name}")
-  public ResponseEntity<List<Drink>> getDrinksByName(@PathVariable(value = "name") String name) {
-    return new ResponseEntity<>(drinkService.getDrinksByName(name), HttpStatus.OK);
-  }
-
   @PostMapping
   public ResponseEntity<List<Drink>> createDrinks(@RequestBody List<Drink> drinks) {
     drinkService.createDrinks(drinks);

--- a/api/src/main/java/com/mtech/vmcs/exception/ControllerAdvisor.java
+++ b/api/src/main/java/com/mtech/vmcs/exception/ControllerAdvisor.java
@@ -1,6 +1,0 @@
-package com.mtech.vmcs.exception;
-
-import org.springframework.web.bind.annotation.ControllerAdvice;
-
-@ControllerAdvice
-public class ControllerAdvisor {}

--- a/api/src/main/java/com/mtech/vmcs/model/enums/ExceptionEnum.java
+++ b/api/src/main/java/com/mtech/vmcs/model/enums/ExceptionEnum.java
@@ -1,3 +1,0 @@
-package com.mtech.vmcs.model.enums;
-
-public enum ExceptionEnum {}

--- a/api/src/main/java/com/mtech/vmcs/repository/DrinkRepository.java
+++ b/api/src/main/java/com/mtech/vmcs/repository/DrinkRepository.java
@@ -3,9 +3,4 @@ package com.mtech.vmcs.repository;
 import com.mtech.vmcs.model.entity.Drink;
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.List;
-
-public interface DrinkRepository extends CrudRepository<Drink, Long> {
-
-  List<Drink> findAllByName(String name);
-}
+public interface DrinkRepository extends CrudRepository<Drink, Long> {}

--- a/api/src/main/java/com/mtech/vmcs/service/DrinkService.java
+++ b/api/src/main/java/com/mtech/vmcs/service/DrinkService.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 public interface DrinkService {
 
-  List<Drink> getDrinksByName(String name);
-
   List<Drink> getAllDrinks();
 
   void createDrinks(List<Drink> drinks);

--- a/api/src/main/java/com/mtech/vmcs/service/impl/DrinkServiceImpl.java
+++ b/api/src/main/java/com/mtech/vmcs/service/impl/DrinkServiceImpl.java
@@ -16,11 +16,6 @@ public class DrinkServiceImpl implements DrinkService {
   @Autowired private DrinkRepository drinkRepository;
 
   @Override
-  public List<Drink> getDrinksByName(String name) {
-    return drinkRepository.findAllByName(name);
-  }
-
-  @Override
   public List<Drink> getAllDrinks() {
     return StreamSupport.stream(drinkRepository.findAll().spliterator(), false)
         .collect(Collectors.toList());

--- a/api/src/main/java/com/mtech/vmcs/service/impl/OrderServiceImpl.java
+++ b/api/src/main/java/com/mtech/vmcs/service/impl/OrderServiceImpl.java
@@ -7,7 +7,7 @@ import com.mtech.vmcs.repository.DrinkRepository;
 import com.mtech.vmcs.service.CoinService;
 import com.mtech.vmcs.service.DrinkService;
 import com.mtech.vmcs.service.OrderService;
-import com.mtech.vmcs.utill.MementoStack;
+import com.mtech.vmcs.util.MementoStack;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/api/src/main/java/com/mtech/vmcs/util/MementoStack.java
+++ b/api/src/main/java/com/mtech/vmcs/util/MementoStack.java
@@ -1,10 +1,10 @@
-package com.mtech.vmcs.utill;
+package com.mtech.vmcs.util;
 
 import java.util.Stack;
 
 public class MementoStack<T> {
 
-  Stack<T> stack = new Stack<>();
+  private final Stack<T> stack = new Stack<>();
 
   public void push(T state) {
     stack.push(state);

--- a/api/src/test/java/com/mtech/vmcs/service/impl/CoinServiceImplTest.java
+++ b/api/src/test/java/com/mtech/vmcs/service/impl/CoinServiceImplTest.java
@@ -19,17 +19,15 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class CoinServiceImplTest {
 
+  List<Coin> storedCoins;
+  List<Coin> insertedCoins;
+  @Mock CoinRepository coinRepository;
+  @InjectMocks CoinServiceImpl coinService;
   private Coin COIN_5C = new Coin(1L, "5c", 5, 1, 1F);
   private Coin COIN_10C = new Coin(2L, "10c", 10, 1, 1F);
   private Coin COIN_20C = new Coin(3L, "20c", 20, 1, 1F);
   private Coin COIN_50C = new Coin(4L, "50c", 50, 1, 1F);
   private Coin COIN_$1 = new Coin(5L, "$1", 100, 1, 1F);
-  List<Coin> storedCoins;
-  List<Coin> insertedCoins;
-
-  @Mock CoinRepository coinRepository;
-
-  @InjectMocks CoinServiceImpl coinService;
 
   @Test
   public void getAllCoins() {

--- a/api/src/test/java/com/mtech/vmcs/service/impl/DrinkServiceImplTest.java
+++ b/api/src/test/java/com/mtech/vmcs/service/impl/DrinkServiceImplTest.java
@@ -18,12 +18,6 @@ class DrinkServiceImplTest {
   @InjectMocks DrinkServiceImpl drinkService;
 
   @Test
-  void getDrinksByName() {
-    drinkService.getDrinksByName(anyString());
-    verify(drinkRepository, times(1)).findAllByName(anyString());
-  }
-
-  @Test
   void getAllDrinks() {
     when(drinkRepository.findAll()).thenReturn(Collections.EMPTY_LIST);
     assertNotNull(drinkService.getAllDrinks());

--- a/api/src/test/java/com/mtech/vmcs/service/impl/OrderServiceImplTest.java
+++ b/api/src/test/java/com/mtech/vmcs/service/impl/OrderServiceImplTest.java
@@ -6,7 +6,7 @@ import com.mtech.vmcs.model.entity.PurchaseOrder;
 import com.mtech.vmcs.repository.DrinkRepository;
 import com.mtech.vmcs.service.CoinService;
 import com.mtech.vmcs.service.DrinkService;
-import com.mtech.vmcs.utill.MementoStack;
+import com.mtech.vmcs.util.MementoStack;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
- Remove some unnecessary code and packages.
- Refactor the typo package name from ```utill``` to ```util```.
- Reformat code.

@pcdotfan @shiyuw09 @AbMonarch @yaoliuchang please help me review the changes at your convenience, thanks.